### PR TITLE
Feat/basic api endpoints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, staging, "feat/**"]
+  pull_request:
+    branches: [main, staging]
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ["8.4"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, pdo, pdo_sqlite, sqlite3, xml, json, tokenizer
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Copy environment file
+        run: cp .env.example .env
+
+      - name: Generate application key
+        run: php artisan key:generate
+
+      - name: Run tests
+        run: php artisan test --compact

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Key components:
 
 Each news provider has a dedicated adapter responsible for fetching and mapping API responses.
 
-Adapters implemented:
+Adapters planned:
 
 * NewsApiAdapter
 * GuardianAdapter
@@ -74,10 +74,10 @@ The aggregation service orchestrates the process of collecting and storing artic
 
 Responsibilities:
 
-* call external news APIs through adapters
-* normalize article data
-* deduplicate articles
-* persist articles to the database
+* Call external news APIs through adapters
+* Normalize article data
+* Deduplicate articles
+* Persist articles to the database
 
 ---
 
@@ -87,10 +87,12 @@ The system uses Laravel's scheduler to periodically ingest articles.
 
 Workflow:
 
+```
 Scheduler
 → FetchArticlesJob
 → Aggregation Service
 → Database update
+```
 
 ---
 
@@ -121,7 +123,9 @@ Response:
 
 ---
 
-### Get Articles
+### Articles
+
+#### List Articles
 
 Retrieve paginated articles.
 
@@ -131,20 +135,18 @@ GET /api/v1/articles
 
 Query parameters:
 
-| Parameter | Description        |
-| --------- | ------------------ |
-| q         | search keyword     |
-| source    | filter by source   |
-| category  | filter by category |
-| author    | filter by author   |
-| from      | start date         |
-| to        | end date           |
-| page      | page number        |
-| per_page  | number of results  |
+| Parameter | Description               |
+| --------- | ------------------------- |
+| q         | Search keyword            |
+| source    | Filter by source slug     |
+| category  | Filter by category slug   |
+| author    | Filter by author name     |
+| from      | Start date (YYYY-MM-DD)   |
+| to        | End date (YYYY-MM-DD)     |
+| page      | Page number               |
+| per_page  | Results per page          |
 
----
-
-### Get Article Detail
+#### Get Article Detail
 
 ```
 GET /api/v1/articles/{id}
@@ -152,18 +154,34 @@ GET /api/v1/articles/{id}
 
 ---
 
-### Get Sources
+### Sources
+
+#### List Sources
 
 ```
 GET /api/v1/sources
 ```
 
+#### Get Source Detail
+
+```
+GET /api/v1/sources/{id}
+```
+
 ---
 
-### Get Categories
+### Categories
+
+#### List Categories
 
 ```
 GET /api/v1/categories
+```
+
+#### Get Category Detail
+
+```
+GET /api/v1/categories/{id}
 ```
 
 ---
@@ -198,7 +216,7 @@ Authentication is handled via **Laravel Sanctum** token-based auth. No sessions 
 | -------- | ---------------------------------- | ----------- |
 | app      | PHP 8.4-FPM (Laravel application)  | —           |
 | nginx    | Web server (reverse proxy to app)  | 8080        |
-| mariadb  | Database                           | 3307        |
+| mariadb  | MariaDB 11 database                | 3307        |
 | redis    | Cache & queue driver               | 6380        |
 | queue    | Horizon worker                     | —           |
 
@@ -210,7 +228,7 @@ Authentication is handled via **Laravel Sanctum** token-based auth. No sessions 
 
 ```bash
 git clone <repository-url>
-cd news-aggregator-backend
+cd laravel-innoscripta-news-aggregator-api
 ```
 
 ---
@@ -224,7 +242,7 @@ cp .env.example .env
 Update the following values in `.env`:
 
 ```env
-DB_DATABASE=innoscripta_news_aggregator
+DB_DATABASE=laravel_innoscripta_news_aggregator_api
 DB_USERNAME=your_db_user
 DB_PASSWORD=your_db_password
 
@@ -251,7 +269,7 @@ docker compose up -d --build
 docker compose exec app composer install
 ```
 
-This runs `composer install`, generates the application key, runs migrations, installs npm dependencies, and builds frontend assets.
+This runs `composer install`, generates the application key, runs migrations, seeds the database, and builds frontend assets.
 
 ---
 
@@ -338,8 +356,9 @@ http://localhost:8080/horizon
 
 This project demonstrates how to design and implement a news aggregation backend with:
 
-* clean architecture
-* normalized data ingestion
-* extensible API integrations
-* flexible search and filtering
-* maintainable code structure
+* Clean layered architecture (Service → Repository → Controller)
+* Normalized data ingestion from heterogeneous external APIs
+* Extensible adapter pattern for adding new news sources
+* Deduplication at the database level (unique constraints on source + external ID and URL)
+* Flexible article search and filtering
+* Maintainable, testable code structure

--- a/app/Http/Controllers/API/V1/ArticleController.php
+++ b/app/Http/Controllers/API/V1/ArticleController.php
@@ -7,15 +7,20 @@ use App\Http\Requests\StoreArticleRequest;
 use App\Http\Requests\UpdateArticleRequest;
 use App\Http\Resources\ArticleResource;
 use App\Models\Article;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class ArticleController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Return a paginated list of articles with their source and categories.
+     *
+     * @return AnonymousResourceCollection<LengthAwarePaginator<ArticleResource>>
      */
-    public function index()
+    public function index(): AnonymousResourceCollection
     {
-        $articles = Article::with(['source'])->paginate();
+        $articles = Article::with(['source', 'categories'])->paginate();
 
         return ArticleResource::collection($articles);
     }
@@ -37,11 +42,11 @@ class ArticleController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * Return a single article with its source and categories.
      */
-    public function show(Article $article)
+    public function show(Article $article): JsonResource
     {
-        $article->load(['source']);
+        $article->load(['source', 'categories']);
 
         return new ArticleResource($article);
     }

--- a/app/Http/Controllers/API/V1/ArticleController.php
+++ b/app/Http/Controllers/API/V1/ArticleController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreArticleRequest;
 use App\Http\Requests\UpdateArticleRequest;
+use App\Http\Resources\ArticleResource;
 use App\Models\Article;
 
 class ArticleController extends Controller
@@ -14,7 +15,9 @@ class ArticleController extends Controller
      */
     public function index()
     {
-        //
+        $articles = Article::with(['source'])->paginate();
+
+        return ArticleResource::collection($articles);
     }
 
     /**
@@ -38,7 +41,9 @@ class ArticleController extends Controller
      */
     public function show(Article $article)
     {
-        //
+        $article->load(['source']);
+
+        return new ArticleResource($article);
     }
 
     /**

--- a/app/Http/Controllers/API/V1/ArticleController.php
+++ b/app/Http/Controllers/API/V1/ArticleController.php
@@ -8,17 +8,15 @@ use App\Http\Requests\UpdateArticleRequest;
 use App\Http\Resources\ArticleResource;
 use App\Models\Article;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Pagination\LengthAwarePaginator;
 
 class ArticleController extends Controller
 {
     /**
-     * Return a paginated list of articles with their source and categories.
+     * Summary of index
      *
-     * @return AnonymousResourceCollection<LengthAwarePaginator<ArticleResource>>
+     * @return AnonymousResourceCollection
      */
-    public function index(): AnonymousResourceCollection
+    public function index()
     {
         $articles = Article::with(['source', 'categories'])->paginate();
 
@@ -42,9 +40,9 @@ class ArticleController extends Controller
     }
 
     /**
-     * Return a single article with its source and categories.
+     * Display the specified resource.
      */
-    public function show(Article $article): JsonResource
+    public function show(Article $article)
     {
         $article->load(['source', 'categories']);
 

--- a/app/Http/Controllers/API/V1/CategoryController.php
+++ b/app/Http/Controllers/API/V1/CategoryController.php
@@ -7,13 +7,18 @@ use App\Http\Requests\StoreCategoryRequest;
 use App\Http\Requests\UpdateCategoryRequest;
 use App\Http\Resources\CategoryResource;
 use App\Models\Category;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class CategoryController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Return all categories.
+     *
+     * @return AnonymousResourceCollection<Collection<CategoryResource>>
      */
-    public function index()
+    public function index(): AnonymousResourceCollection
     {
         return CategoryResource::collection(Category::get());
     }
@@ -35,9 +40,9 @@ class CategoryController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * Return a single category.
      */
-    public function show(Category $category)
+    public function show(Category $category): JsonResource
     {
         return new CategoryResource($category);
     }

--- a/app/Http/Controllers/API/V1/CategoryController.php
+++ b/app/Http/Controllers/API/V1/CategoryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreCategoryRequest;
 use App\Http\Requests\UpdateCategoryRequest;
+use App\Http\Resources\CategoryResource;
 use App\Models\Category;
 
 class CategoryController extends Controller
@@ -14,7 +15,7 @@ class CategoryController extends Controller
      */
     public function index()
     {
-        //
+        return CategoryResource::collection(Category::get());
     }
 
     /**
@@ -38,7 +39,7 @@ class CategoryController extends Controller
      */
     public function show(Category $category)
     {
-        //
+        return new CategoryResource($category);
     }
 
     /**

--- a/app/Http/Controllers/API/V1/SourceController.php
+++ b/app/Http/Controllers/API/V1/SourceController.php
@@ -7,13 +7,18 @@ use App\Http\Requests\StoreSourceRequest;
 use App\Http\Requests\UpdateSourceRequest;
 use App\Http\Resources\SourceResource;
 use App\Models\Source;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class SourceController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Return all news sources.
+     *
+     * @return AnonymousResourceCollection<Collection<SourceResource>>
      */
-    public function index()
+    public function index(): AnonymousResourceCollection
     {
         return SourceResource::collection(Source::get());
     }
@@ -35,9 +40,9 @@ class SourceController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * Return a single news source.
      */
-    public function show(Source $source)
+    public function show(Source $source): JsonResource
     {
         return new SourceResource($source);
     }

--- a/app/Http/Controllers/API/V1/SourceController.php
+++ b/app/Http/Controllers/API/V1/SourceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSourceRequest;
 use App\Http\Requests\UpdateSourceRequest;
+use App\Http\Resources\SourceResource;
 use App\Models\Source;
 
 class SourceController extends Controller
@@ -14,7 +15,7 @@ class SourceController extends Controller
      */
     public function index()
     {
-        //
+        return SourceResource::collection(Source::get());
     }
 
     /**
@@ -38,7 +39,7 @@ class SourceController extends Controller
      */
     public function show(Source $source)
     {
-        //
+        return new SourceResource($source);
     }
 
     /**

--- a/app/Http/Resources/ArticleResource.php
+++ b/app/Http/Resources/ArticleResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ArticleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/ArticleResource.php
+++ b/app/Http/Resources/ArticleResource.php
@@ -14,6 +14,24 @@ class ArticleResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id' => $this->id,
+            'source_id' => $this->source_id,
+            'external_id' => $this->external_id,
+            'title' => $this->title,
+            'description' => $this->description,
+            'content' => $this->content,
+            'author' => $this->author,
+            'url' => $this->url,
+            'image_url' => $this->image_url,
+            'published_at' => $this->published_at,
+            'fetched_at' => $this->fetched_at,
+
+            'source' => new SourceResource($this->whenLoaded('source')),
+            'categories' => CategoryResource::collection($this->whenLoaded('categories')),
+
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
     }
 }

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CategoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -20,7 +20,7 @@ class CategoryResource extends JsonResource
             'slug' => $this->slug,
 
             'created_at' => $this->created_at,
-            'upated_at' => $this->updated_at,
+            'updated_at' => $this->updated_at,
         ];
     }
 }

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -14,6 +14,13 @@ class CategoryResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+
+            'created_at' => $this->created_at,
+            'upated_at' => $this->updated_at,
+        ];
     }
 }

--- a/app/Http/Resources/SourceResource.php
+++ b/app/Http/Resources/SourceResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SourceResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/SourceResource.php
+++ b/app/Http/Resources/SourceResource.php
@@ -14,6 +14,14 @@ class SourceResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'is_active' => $this->is_active,
+            'last_fetched_at' => $this->last_fetched_at,
+
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
     }
 }

--- a/app/Http/Resources/SourceResource.php
+++ b/app/Http/Resources/SourceResource.php
@@ -16,6 +16,7 @@ class SourceResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'name' => $this->name,
             'slug' => $this->slug,
             'is_active' => $this->is_active,
             'last_fetched_at' => $this->last_fetched_at,

--- a/database/factories/ArticleFactory.php
+++ b/database/factories/ArticleFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Article;
+use App\Models\Category;
 use App\Models\Source;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -17,7 +18,7 @@ class ArticleFactory extends Factory
     public function definition(): array
     {
         return [
-            'source_id' => Source::factory(),
+            'source_id' => Source::inRandomOrder()->value('id') ?? Source::factory(),
             'external_id' => fake()->unique()->uuid(),
             'title' => fake()->sentence(),
             'description' => fake()->paragraph(),
@@ -28,5 +29,25 @@ class ArticleFactory extends Factory
             'published_at' => fake()->dateTimeBetween('-1 month', 'now'),
             'fetched_at' => now(),
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Article $article) {
+            $categoryIds = Category::inRandomOrder()->limit(2)->pluck('id');
+
+            if ($categoryIds->isNotEmpty()) {
+                $article->categories()->attach($categoryIds);
+            }
+        });
+    }
+
+    public function withCategories(int $count = 2): static
+    {
+        return $this->afterCreating(function (Article $article) use ($count) {
+            $article->categories()->sync(
+                Category::factory()->count($count)->create()->pluck('id')
+            );
+        });
     }
 }

--- a/database/factories/ArticleFactory.php
+++ b/database/factories/ArticleFactory.php
@@ -31,23 +31,11 @@ class ArticleFactory extends Factory
         ];
     }
 
-    public function configure(): static
-    {
-        return $this->afterCreating(function (Article $article) {
-            $categoryIds = Category::inRandomOrder()->limit(2)->pluck('id');
-
-            if ($categoryIds->isNotEmpty()) {
-                $article->categories()->attach($categoryIds);
-            }
-        });
-    }
-
     public function withCategories(int $count = 2): static
     {
         return $this->afterCreating(function (Article $article) use ($count) {
-            $article->categories()->sync(
-                Category::factory()->count($count)->create()->pluck('id')
-            );
+            $categoryIds = Category::inRandomOrder()->limit($count)->pluck('id');
+            $article->categories()->sync($categoryIds);
         });
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,5 +32,6 @@
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
+        <env name="LOG_CHANNEL" value="null"/>
     </php>
 </phpunit>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\API\V1\ArticleController;
+use App\Http\Controllers\API\V1\CategoryController;
+use App\Http\Controllers\API\V1\SourceController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json([
@@ -8,3 +11,20 @@ Route::get('/health', fn () => response()->json([
     'version' => '1.0.0',
     'timestamp' => now()->toIso8601String(),
 ]));
+
+Route::prefix('/v1')->group(function () {
+    Route::controller(ArticleController::class)->group(function () {
+        Route::get('/articles', 'index');
+        Route::get('/articles/{article}', 'show');
+    });
+
+    Route::controller(CategoryController::class)->group(function () {
+        Route::get('/categories', 'index');
+        Route::get('/categories/{category}', 'show');
+    });
+
+    Route::controller(SourceController::class)->group(function () {
+        Route::get('/sources', 'index');
+        Route::get('/sources/{source}', 'show');
+    });
+});

--- a/tests/Feature/Api/V1/ArticleTest.php
+++ b/tests/Feature/Api/V1/ArticleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Article;
+use App\Models\Category;
 use App\Models\Source;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -62,6 +63,7 @@ test('returns 404 for a soft-deleted article', function () {
 });
 
 test('returns categories with an article on the index', function () {
+    Category::factory()->count(2)->create();
     Article::factory()->withCategories(2)->create();
 
     $response = $this->getJson('/api/v1/articles')->assertSuccessful();
@@ -70,6 +72,7 @@ test('returns categories with an article on the index', function () {
 });
 
 test('returns categories with an article on show', function () {
+    Category::factory()->count(3)->create();
     $article = Article::factory()->withCategories(3)->create();
 
     $response = $this->getJson("/api/v1/articles/{$article->id}")->assertSuccessful();
@@ -86,8 +89,8 @@ test('returns an empty categories array for an article with no categories', func
 });
 
 test('returns correct category fields with an article', function () {
+    $category = Category::factory()->create();
     $article = Article::factory()->withCategories(1)->create();
-    $category = $article->categories->first();
 
     $response = $this->getJson("/api/v1/articles/{$article->id}")->assertSuccessful();
 

--- a/tests/Feature/Api/V1/ArticleTest.php
+++ b/tests/Feature/Api/V1/ArticleTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\Article;
+use App\Models\Source;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+pest()->use(RefreshDatabase::class);
+
+test('returns a paginated list of articles', function () {
+    Article::factory()->count(3)->create();
+
+    $this->getJson('/api/v1/articles')
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            'data' => [['id', 'title', 'url', 'published_at']],
+            'links',
+            'meta',
+        ]);
+});
+
+test('returns an empty list when no articles exist', function () {
+    $this->getJson('/api/v1/articles')
+        ->assertSuccessful()
+        ->assertJson(['data' => []]);
+});
+
+test('eager loads the source relationship on the index', function () {
+    $source = Source::factory()->create();
+    Article::factory()->create(['source_id' => $source->id]);
+
+    $response = $this->getJson('/api/v1/articles')->assertSuccessful();
+
+    expect($response->json('data.0.source.id'))->toBe($source->id);
+});
+
+test('returns a single article', function () {
+    $article = Article::factory()->create();
+
+    $this->getJson("/api/v1/articles/{$article->id}")
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $article->id, 'title' => $article->title]);
+});
+
+test('loads the source relationship on show', function () {
+    $source = Source::factory()->create();
+    $article = Article::factory()->create(['source_id' => $source->id]);
+
+    $response = $this->getJson("/api/v1/articles/{$article->id}")->assertSuccessful();
+
+    expect($response->json('data.source.id'))->toBe($source->id);
+});
+
+test('returns 404 for a non-existent article', function () {
+    $this->getJson('/api/v1/articles/999')->assertNotFound();
+});
+
+test('returns 404 for a soft-deleted article', function () {
+    $article = Article::factory()->create();
+    $article->delete();
+
+    $this->getJson("/api/v1/articles/{$article->id}")->assertNotFound();
+});

--- a/tests/Feature/Api/V1/ArticleTest.php
+++ b/tests/Feature/Api/V1/ArticleTest.php
@@ -60,3 +60,37 @@ test('returns 404 for a soft-deleted article', function () {
 
     $this->getJson("/api/v1/articles/{$article->id}")->assertNotFound();
 });
+
+test('returns categories with an article on the index', function () {
+    Article::factory()->withCategories(2)->create();
+
+    $response = $this->getJson('/api/v1/articles')->assertSuccessful();
+
+    expect($response->json('data.0.categories'))->toHaveCount(2);
+});
+
+test('returns categories with an article on show', function () {
+    $article = Article::factory()->withCategories(3)->create();
+
+    $response = $this->getJson("/api/v1/articles/{$article->id}")->assertSuccessful();
+
+    expect($response->json('data.categories'))->toHaveCount(3);
+});
+
+test('returns an empty categories array for an article with no categories', function () {
+    $article = Article::factory()->create();
+
+    $response = $this->getJson("/api/v1/articles/{$article->id}")->assertSuccessful();
+
+    expect($response->json('data.categories'))->toBeEmpty();
+});
+
+test('returns correct category fields with an article', function () {
+    $article = Article::factory()->withCategories(1)->create();
+    $category = $article->categories->first();
+
+    $response = $this->getJson("/api/v1/articles/{$article->id}")->assertSuccessful();
+
+    expect($response->json('data.categories.0'))
+        ->toMatchArray(['id' => $category->id, 'name' => $category->name, 'slug' => $category->slug]);
+});

--- a/tests/Feature/Api/V1/CategoryTest.php
+++ b/tests/Feature/Api/V1/CategoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+pest()->use(RefreshDatabase::class);
+
+test('returns all categories', function () {
+    Category::factory()->count(3)->create();
+
+    $this->getJson('/api/v1/categories')
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            'data' => [['id', 'name', 'slug']],
+        ])
+        ->assertJsonCount(3, 'data');
+});
+
+test('returns an empty list when no categories exist', function () {
+    $this->getJson('/api/v1/categories')
+        ->assertSuccessful()
+        ->assertJson(['data' => []]);
+});
+
+test('returns a single category', function () {
+    $category = Category::factory()->create();
+
+    $this->getJson("/api/v1/categories/{$category->id}")
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $category->id, 'name' => $category->name]);
+});
+
+test('returns 404 for a non-existent category', function () {
+    $this->getJson('/api/v1/categories/999')->assertNotFound();
+});

--- a/tests/Feature/Api/V1/SourceTest.php
+++ b/tests/Feature/Api/V1/SourceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Source;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+pest()->use(RefreshDatabase::class);
+
+test('returns all sources', function () {
+    Source::factory()->count(3)->create();
+
+    $this->getJson('/api/v1/sources')
+        ->assertSuccessful()
+        ->assertJsonStructure([
+            'data' => [['id', 'name', 'slug']],
+        ])
+        ->assertJsonCount(3, 'data');
+});
+
+test('returns an empty list when no sources exist', function () {
+    $this->getJson('/api/v1/sources')
+        ->assertSuccessful()
+        ->assertJson(['data' => []]);
+});
+
+test('returns a single source', function () {
+    $source = Source::factory()->create();
+
+    $this->getJson("/api/v1/sources/{$source->id}")
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $source->id, 'name' => $source->name]);
+});
+
+test('returns 404 for a non-existent source', function () {
+    $this->getJson('/api/v1/sources/999')->assertNotFound();
+});


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                               
  Implements the basic read-only REST API endpoints required by issue #16. This covers article listing/retrieval with related data, plus source and category indexes — all under the versioned /api/v1/ namespace.                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                               
  What's included                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                               
  - ArticleController — index (paginated, 20/page) and show endpoints with eager-loaded source and categories to prevent N+1 queries                                                                                                                                                                                                                                           
  - SourceController — index endpoint returning all sources                                                                                                                
  - CategoryController — index endpoint returning all categories                                                                                                                                                                                                                                                                                                               
  - API routes registered under /api/v1/articles, /api/v1/sources, /api/v1/categories                                                                                                                                                                                                                                                                                          
  - Eloquent Resources (ArticleResource, SourceResource, CategoryResource) for consistent JSON response shaping                                                                                                                                                                                                                                                                
  - Models + Migrations for articles, sources, categories, and the article_category pivot table                                                                                                                                                                                                                                                                                
  - Factories & Seeders for all three models, including deduplication constraint tests                                                                                                                                                                                                                                                                                         
  - CI workflow (.github/workflows/tests.yml) to run the Pest test suite on every push                                                                                                                                                                                                                                                                                         
  - Feature tests covering index/show for all three resources and article deduplication constraints                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                               
  Closes                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                               
  Closes #16                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                           
  ---
  Test plan
  - php artisan test --compact passes all feature tests                                                                                                                                                                                                                                                                                                                        
  - GET /api/v1/articles returns paginated JSON with source and categories relationships
  - GET /api/v1/articles/{id} returns single article with relationships                                                                                                                                                                                                                                                                                                        
  - GET /api/v1/sources and GET /api/v1/categories return full lists                                                                                                                                                                                                                                                                                                           
  - No N+1 queries (verify via Telescope)
  
  closes #16 