### PR TITLE
Feat/newsapi adapter

### DIFF
--- a/app/Contracts/NewsSourceInterface.php
+++ b/app/Contracts/NewsSourceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Contracts;
+
+interface NewsSourceInterface
+{
+    public function fetch(): array;
+
+    public function normalize(array $data): array;
+}

--- a/app/Services/Adapters/NewsApiAdapter.php
+++ b/app/Services/Adapters/NewsApiAdapter.php
@@ -36,7 +36,7 @@ class NewsApiAdapter implements NewsSourceInterface
         try {
             Log::info('NewsAPI: Fetching articles', [
                 'endpoint' => '/everything',
-                'from_date' => Carbon::now()->toIso8601String(),
+                'fetched_at' => Carbon::now()->toIso8601String(),
             ]);
 
             $response = Http::baseUrl($baseUrl)
@@ -55,7 +55,7 @@ class NewsApiAdapter implements NewsSourceInterface
             $data = $response->json();
             $articles = $data['articles'] ?? [];
 
-            Log::info('NewsAPI: fetched article successfully', [
+            Log::info('NewsAPI: fetched articles successfully', [
                 'count' => count($articles),
                 'total_results' => $data['totalResults'] ?? 0,
             ]);

--- a/app/Services/Adapters/NewsApiAdapter.php
+++ b/app/Services/Adapters/NewsApiAdapter.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Services\Adapters;
+
+use App\Contracts\NewsSourceInterface;
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class NewsApiAdapter implements NewsSourceInterface
+{
+    public function __construct(private array $config = [])
+    {
+        $this->config = config('news.sources.newsapi');
+    }
+
+    /**
+     * Fetch raw articles from the NewsAPI /everything endpoint.
+     *
+     * @return array<int, array<string, mixed>>
+     *
+     * @throws RequestException
+     * @throws ConnectionException
+     * @throws Exception
+     */
+    public function fetch(): array
+    {
+        $baseUrl = $this->config['base_url'];
+        $apiKey = $this->config['api_key'];
+        $timeout = $this->config['timeout'];
+        $endpoint = $this->config['endpoints']['everything'];
+
+        try {
+            Log::info('NewsAPI: Fetching articles', [
+                'endpoint' => '/everything',
+                'from_date' => Carbon::now()->toIso8601String(),
+            ]);
+
+            $response = Http::baseUrl($baseUrl)
+                ->withQueryParameters([
+                    'apiKey' => $apiKey,
+                    'q' => 'AI',
+                    'language' => 'en',
+                    'sortBy' => 'publishedAt',
+                    'pageSize' => 10,
+                    'page' => 1,
+                ])->timeout($timeout)
+                ->retry(3, 100)
+                ->throw()
+                ->get($endpoint);
+
+            $data = $response->json();
+            $articles = $data['articles'] ?? [];
+
+            Log::info('NewsAPI: fetched article successfully', [
+                'count' => count($articles),
+                'total_results' => $data['totalResults'] ?? 0,
+            ]);
+
+            return $articles;
+        } catch (RequestException $re) {
+            Log::error('NewsAPI HTTP error', [
+                'status' => $re->response->status(),
+                'message' => $re->getMessage(),
+            ]);
+
+            return [];
+        } catch (ConnectionException $ce) {
+            Log::error('NewsAPI connection error', [
+                'message' => $ce->getMessage(),
+            ]);
+
+            throw $ce;
+        } catch (Exception $e) {
+            Log::error('NewsAPI adapter error', [
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            throw $e;
+        }
+
+    }
+
+    /**
+     * Normalize a single raw NewsAPI article into the common article schema.
+     *
+     * @param  array{
+     *     url?: string,
+     *     title?: string,
+     *     description?: string,
+     *     content?: string,
+     *     author?: string,
+     *     urlToImage?: string,
+     *     publishedAt?: string,
+     * }  $data
+     * @return array{
+     *     external_id: string,
+     *     title: string,
+     *     description: string|null,
+     *     content: string|null,
+     *     author: string|null,
+     *     url: string,
+     *     image_url: string|null,
+     *     published_at: string,
+     *     categories: array<string>,
+     * }
+     */
+    public function normalize(array $data): array
+    {
+        if (empty($data['url'])) {
+            return [];
+        }
+
+        $externalId = md5($data['url']);
+        $publishedAt = isset($data['publishedAt']) ? Carbon::parse($data['publishedAt']) : Carbon::now();
+        $categories = ['world'];
+
+        return [
+            'external_id' => $externalId,
+            'title' => $data['title'] ?? 'Untitled',
+            'description' => $data['description'] ?? null,
+            'content' => $data['content'] ?? null,
+            'author' => $data['author'] ?? null,
+            'url' => $data['url'] ?? '',
+            'image_url' => $data['urlToImage'] ?? null,
+            'published_at' => $publishedAt->toDateTimeString(),
+            'categories' => $categories,
+        ];
+    }
+}

--- a/config/news.php
+++ b/config/news.php
@@ -49,7 +49,7 @@ return [
             'enabled' => env('NEWS_SOURCE_NYTIMES_ENABLED', true),
             'timeout' => 30,
             'endpoints' => [
-                'article_search' => '/articlesearch.json',
+                'archive' => '/archive/v1',
             ],
         ],
     ],

--- a/docs/task/backend-case-study.md
+++ b/docs/task/backend-case-study.md
@@ -1,0 +1,102 @@
+# Backend Developer Take Home Challenge
+
+## Challenge Guidelines
+
+Welcome to the take-home challenge for the Backend Web Developer position.  
+We are excited to see your skills and experience in action.
+
+The challenge is to build the backend functionality for a **news aggregator website** that pulls articles from various sources and serves them to the frontend application.
+
+---
+
+## Requirements
+
+### Data Sources (Choose at least 3)
+
+You may use at least **3 of the following APIs**:
+
+- **NewsAPI**  
+  A comprehensive API providing access to articles from more than 70,000 sources including newspapers, magazines, and blogs. Supports multiple languages, categories, search, and filtering.
+
+- **OpenNews**  
+  Provides access to a wide range of news content. Allows retrieval based on keywords, categories, and sources.
+
+- **NewsCred**  
+  Offers access to various news sources. Supports filtering by keywords, categories, authors, publications, and topics.
+
+- **The Guardian API**  
+  Access articles from The Guardian with support for categories, search, and filtering.
+
+- **New York Times API**  
+  Provides access to NYT articles with filtering and categorization support.
+
+- **BBC News API**  
+  Access trusted news articles from BBC across multiple categories.
+
+- **NewsAPI.org**  
+  Aggregates news from thousands of publications, blogs, and magazines with search and filtering capabilities.
+
+---
+
+## Core Tasks
+
+### 1. Data Aggregation and Storage
+
+- Fetch articles from selected data sources (minimum 3)
+- Store them in a local database
+- Ensure data is **regularly updated** from live sources
+
+---
+
+### 2. API Endpoints
+
+Create API endpoints that allow the frontend to:
+
+- Retrieve articles
+- Search by keywords
+- Filter by:
+  - Date
+  - Category
+  - Source
+- Apply user preferences:
+  - Selected sources
+  - Categories
+  - Authors
+
+---
+
+## Expected Output
+
+- A backend project built using **PHP Laravel**
+- Implementation of:
+  - Data fetching and storage mechanisms
+  - Scheduled or automated updates
+  - API endpoints for frontend consumption
+
+---
+
+## Engineering Principles
+
+Apply best practices:
+
+- **DRY** (Don't Repeat Yourself)
+- **KISS** (Keep It Simple, Stupid)
+- **SOLID Principles**:
+  - Single Responsibility
+  - Open/Closed
+  - Liskov Substitution
+  - Interface Segregation
+  - Dependency Inversion
+
+---
+
+## Notes
+
+- This challenge focuses **only on backend development**
+- **User authentication is NOT required**
+
+---
+
+## Contact
+
+📧 casestudy@innoscripta.com

--- a/tests/Feature/Services/NewsApiAdapterTest.php
+++ b/tests/Feature/Services/NewsApiAdapterTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use App\Services\Adapters\NewsApiAdapter;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+// ---------------------------------------------------------------------------
+// normalize()
+// ---------------------------------------------------------------------------
+
+test('normalize returns mapped article for valid data', function () {
+    $adapter = new NewsApiAdapter;
+
+    $raw = [
+        'url' => 'https://example.com/article-1',
+        'title' => 'Test Article',
+        'description' => 'A short description.',
+        'content' => 'Full article content.',
+        'author' => 'Jane Doe',
+        'urlToImage' => 'https://example.com/image.jpg',
+        'publishedAt' => '2024-01-15T10:00:00Z',
+    ];
+
+    $result = $adapter->normalize($raw);
+
+    expect($result)
+        ->toHaveKeys(['external_id', 'title', 'description', 'content', 'author', 'url', 'image_url', 'published_at', 'categories'])
+        ->and($result['external_id'])->toBe(md5('https://example.com/article-1'))
+        ->and($result['title'])->toBe('Test Article')
+        ->and($result['url'])->toBe('https://example.com/article-1')
+        ->and($result['image_url'])->toBe('https://example.com/image.jpg')
+        ->and($result['categories'])->toBe(['world']);
+});
+
+test('normalize returns empty array when url is missing', function () {
+    $adapter = new NewsApiAdapter;
+
+    expect($adapter->normalize([]))->toBe([])
+        ->and($adapter->normalize(['url' => '']))->toBe([])
+        ->and($adapter->normalize(['title' => 'No URL here']))->toBe([]);
+});
+
+test('normalize uses Untitled when title is missing', function () {
+    $adapter = new NewsApiAdapter;
+
+    $result = $adapter->normalize(['url' => 'https://example.com/no-title']);
+
+    expect($result['title'])->toBe('Untitled');
+});
+
+test('normalize sets nullable fields to null when absent', function () {
+    $adapter = new NewsApiAdapter;
+
+    $result = $adapter->normalize(['url' => 'https://example.com/minimal']);
+
+    expect($result['description'])->toBeNull()
+        ->and($result['content'])->toBeNull()
+        ->and($result['author'])->toBeNull()
+        ->and($result['image_url'])->toBeNull();
+});
+
+test('normalize falls back to current time when publishedAt is missing', function () {
+    $adapter = new NewsApiAdapter;
+
+    $before = now()->subSecond();
+    $result = $adapter->normalize(['url' => 'https://example.com/no-date']);
+    $after = now()->addSecond();
+
+    $publishedAt = \Carbon\Carbon::parse($result['published_at']);
+
+    expect($publishedAt->between($before, $after))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// fetch()
+// ---------------------------------------------------------------------------
+
+test('fetch returns articles on successful response', function () {
+    Http::fake([
+        '*' => Http::response([
+            'status' => 'ok',
+            'totalResults' => 2,
+            'articles' => [
+                ['title' => 'Article One', 'url' => 'https://example.com/1'],
+                ['title' => 'Article Two', 'url' => 'https://example.com/2'],
+            ],
+        ], 200),
+    ]);
+
+    $adapter = new NewsApiAdapter;
+    $articles = $adapter->fetch();
+
+    expect($articles)->toHaveCount(2)
+        ->and($articles[0]['title'])->toBe('Article One');
+});
+
+test('fetch returns empty array when articles key is absent', function () {
+    Http::fake(['*' => Http::response(['status' => 'ok'], 200)]);
+
+    $adapter = new NewsApiAdapter;
+
+    expect($adapter->fetch())->toBe([]);
+});
+
+test('fetch returns empty array and logs error on http error', function () {
+    Http::fake(['*' => Http::response(['message' => 'Too Many Requests'], 429)]);
+
+    Log::shouldReceive('info')->once();
+    Log::shouldReceive('error')->once()->with('NewsAPI HTTP error', \Mockery::type('array'));
+
+    $adapter = new NewsApiAdapter;
+
+    expect($adapter->fetch())->toBe([]);
+});
+
+test('fetch re-throws and logs on connection error', function () {
+    Http::fake(function () {
+        throw new ConnectionException('Could not connect');
+    });
+
+    Log::shouldReceive('info')->once();
+    Log::shouldReceive('error')->once()->with('NewsAPI connection error', \Mockery::type('array'));
+
+    $adapter = new NewsApiAdapter;
+
+    expect(fn () => $adapter->fetch())->toThrow(ConnectionException::class);
+});


### PR DESCRIPTION
● feat: NewsAPI adapter — contract interface, adapter implementation, and tests                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                             
  ## Summary                                                                                                                                                                                                                                                                                                                                                                   
   
  - Add `NewsSourceInterface` contract (`fetch()` + `normalize()`) as the shared interface for all news source adapters                                                                                                                                                                                                                                                        
  - Implement `NewsApiAdapter` against the contract — fetches from the `/everything` endpoint, normalizes raw API responses to the project's internal article schema, with structured error handling for HTTP errors, connection failures, and generic exceptions
  - Guard `normalize()` against empty URL to prevent `md5('')` collision on the composite `(source_id, external_id)` unique constraint                                                                                                                                                                                                                                         
  - Add PHPDoc array shape annotations on both methods to document the expected NewsAPI response structure and normalized output schema                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                               
  ## Changes                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                               
  | File | What |                                                                                                                                                                                                                                                                                                                                                              
  |------|------|
  | `app/Contracts/NewsSourceInterface.php` | New — adapter contract with `fetch()` and `normalize()` |                                                                                                                                                                                                                                                                        
  | `app/Services/Adapters/NewsApiAdapter.php` | New — NewsAPI adapter implementation |                                                                                                                                                                                                                                                                                        
  | `config/news.php` | Fix NYTimes endpoint key (`article_search` → `archive`) |
  | `tests/Feature/Services/NewsApiAdapterTest.php` | New — 9 tests covering normalize edge cases and fetch error branches |                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                               
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                               
  - [x] `normalize()` — valid data maps all fields correctly                                                                                                           
  - [x] `normalize()` — returns `[]` when `url` is missing or empty
  - [x] `normalize()` — fallback to `'Untitled'` when title absent                                                                                                                                                                                                                                                                                                             
  - [x] `normalize()` — nullable fields (`description`, `content`, `author`, `image_url`) → `null`
  - [x] `normalize()` — fallback to `now()` when `publishedAt` absent                                                                                                                                                                                                                                                                                                          
  - [x] `fetch()` — returns articles on 200 response                                                                                                                   
  - [x] `fetch()` — returns `[]` when `articles` key absent                                                                                                                                                                                                                                                                                                                    
  - [x] `fetch()` — returns `[]` and logs error on HTTP error (4xx/5xx)                                                                                                
  - [x] `fetch()` — re-throws and logs on `ConnectionException`

Relate #17 