### PR TITLE
  feat: implement aggregation service, fetch jobs, and article filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Key components:
 
 Each news provider has a dedicated adapter responsible for fetching and mapping API responses.
 
-Adapters planned:
+Adapters implemented:
 
-* NewsApiAdapter
-* GuardianAdapter
-* NYTimesAdapter
+* `NewsApiAdapter` — fetches from NewsAPI `/everything` endpoint
+* `GuardianAdapter` — fetches from The Guardian `/search` endpoint
+* `NYTimesAdapter` — fetches from NYTimes Archive API
 
 ---
 
@@ -74,23 +74,36 @@ The aggregation service orchestrates the process of collecting and storing artic
 
 Responsibilities:
 
-* Call external news APIs through adapters
-* Normalize article data
-* Deduplicate articles
-* Persist articles to the database
+* Receive normalized article data from adapters
+* Deduplicate articles via `updateOrCreate` on `(source_id, external_id)`
+* Persist articles and sync categories to the database
+
+---
+
+**Background Jobs**
+
+Each source runs as an independent `FetchArticlesJob` on the queue. Jobs are isolated per source so a failing source does not block others.
+
+Job configuration:
+
+* Retries: 3 attempts
+* Backoff: 30s → 2min → 10min
+* Timeout: 120 seconds
+* Failed jobs logged to `failed_jobs` table
 
 ---
 
 **Scheduler**
 
-The system uses Laravel's scheduler to periodically ingest articles.
+The system uses Laravel's scheduler to automatically ingest articles daily at midnight (server time).
 
 Workflow:
 
 ```
-Scheduler
-→ FetchArticlesJob
-→ Aggregation Service
+Scheduler (daily 00:00)
+→ AggregateNewsCommand
+→ FetchArticlesJob (one per active source, queued)
+→ NewsAggregationService::saveArticle()
 → Database update
 ```
 
@@ -332,12 +345,60 @@ docker compose down -v
 
 ---
 
-# Running the Scheduler
+# News Aggregation
 
-The `queue` container runs **Horizon**, which processes queued jobs from Redis. The Laravel scheduler (for periodic tasks like article ingestion) is a separate process and must be started manually:
+### Trigger Manually
+
+Run article ingestion on demand (dispatches one job per active source to the queue):
 
 ```bash
+php artisan news:aggregate
+
+# Inside Docker
+docker compose exec app php artisan news:aggregate
+```
+
+### Verify Articles Were Fetched
+
+```bash
+php artisan tinker --execute "echo App\Models\Article::count();"
+php artisan tinker --execute "App\Models\Source::all(['name','last_fetched_at'])->each(fn(\$s) => dump(\$s->toArray()));"
+```
+
+### Automatic Schedule
+
+The scheduler runs `news:aggregate` every day at **00:00 server time**.
+
+Verify the schedule:
+
+```bash
+php artisan schedule:list
+```
+
+To run the scheduler process (required for automatic execution):
+
+```bash
+# Local development
+php artisan schedule:work
+
+# Inside Docker
 docker compose exec app php artisan schedule:work
+```
+
+> **Timezone note:** The scheduler uses the timezone defined in `config/app.php` (`APP_TIMEZONE`). Defaults to `UTC`. Set `APP_TIMEZONE=Asia/Jakarta` in `.env` if your server runs on WIB.
+
+### Monitor Queue Jobs
+
+Horizon dashboard shows pending, processing, completed, and failed jobs:
+
+```
+http://localhost:8080/horizon
+```
+
+Retry failed jobs manually:
+
+```bash
+php artisan queue:retry all
 ```
 
 ---

--- a/app/Console/Commands/AggregateNewsCommand.php
+++ b/app/Console/Commands/AggregateNewsCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\FetchArticlesJob;
+use App\Models\Source;
+use Illuminate\Console\Command;
+
+class AggregateNewsCommand extends Command
+{
+    protected $signature = 'news:aggregate';
+
+    protected $description = 'Dispatch fetch jobs for all active news sources';
+
+    public function handle(): int
+    {
+        $sources = Source::query()->where('is_active', true)->get();
+
+        if ($sources->isEmpty()) {
+            $this->warn('No active sources found.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($sources as $source) {
+            FetchArticlesJob::dispatch($source->slug);
+            $this->info("Dispatched job for: {$source->name}");
+        }
+
+        $this->info("Total {$sources->count()} job(s) dispatched to queue.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/API/V1/ArticleController.php
+++ b/app/Http/Controllers/API/V1/ArticleController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\ListArticlesRequest;
 use App\Http\Requests\StoreArticleRequest;
 use App\Http\Requests\UpdateArticleRequest;
 use App\Http\Resources\ArticleResource;
@@ -11,16 +12,15 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ArticleController extends Controller
 {
-    /**
-     * Summary of index
-     *
-     * @return AnonymousResourceCollection
-     */
-    public function index()
+    public function index(ListArticlesRequest $request): AnonymousResourceCollection
     {
-        $articles = Article::with(['source', 'categories'])->paginate();
+        $query = Article::with(['source', 'categories']);
 
-        return ArticleResource::collection($articles);
+        if ($q = $request->string('q')->trim()->value()) {
+            $query->whereFullText(['title', 'description', 'content'], $q);
+        }
+
+        return ArticleResource::collection($query->paginate());
     }
 
     /**

--- a/app/Http/Requests/ListArticlesRequest.php
+++ b/app/Http/Requests/ListArticlesRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListArticlesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'q' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Jobs/FetchArticlesJob.php
+++ b/app/Jobs/FetchArticlesJob.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Contracts\NewsSourceInterface;
+use App\Models\Source;
+use App\Services\Adapters\GuardianAdapter;
+use App\Services\Adapters\NewsApiAdapter;
+use App\Services\Adapters\NYTimesAdapter;
+use App\Services\NewsAggregationService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use Throwable;
+
+class FetchArticlesJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    /** @var array<int> */
+    public array $backoff = [30, 120, 600];
+
+    public int $timeout = 120;
+
+    public function __construct(public readonly string $sourceSlug) {}
+
+    public function handle(NewsAggregationService $service): void
+    {
+        $source = Source::query()
+            ->where('slug', $this->sourceSlug)
+            ->where('is_active', true)
+            ->firstOrFail();
+
+        $adapter = $this->resolveAdapter($this->sourceSlug);
+        $rawArticles = $adapter->fetch();
+
+        $saved = 0;
+
+        foreach ($rawArticles as $rawArticle) {
+            try {
+                $normalized = $adapter->normalize($rawArticle);
+                $service->saveArticle($source, $normalized);
+                $saved++;
+            } catch (Throwable $e) {
+                Log::warning('Failed to save article', [
+                    'source' => $this->sourceSlug,
+                    'url' => $rawArticle['url'] ?? $rawArticle['webUrl'] ?? 'unknown',
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $source->update(['last_fetched_at' => now()]);
+
+        Log::info('FetchArticlesJob completed', [
+            'source' => $this->sourceSlug,
+            'fetched' => count($rawArticles),
+            'saved' => $saved,
+        ]);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::critical('FetchArticlesJob exhausted all retries', [
+            'source' => $this->sourceSlug,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+
+    private function resolveAdapter(string $slug): NewsSourceInterface
+    {
+        return match ($slug) {
+            'newsapi' => app(NewsApiAdapter::class),
+            'guardian' => app(GuardianAdapter::class),
+            'nytimes' => app(NYTimesAdapter::class),
+            default => throw new InvalidArgumentException("No adapter registered for source: {$slug}"),
+        };
+    }
+}

--- a/app/Services/Adapters/GuardianAdapter.php
+++ b/app/Services/Adapters/GuardianAdapter.php
@@ -13,6 +13,10 @@ use Illuminate\Support\Facades\Log;
 
 class GuardianAdapter implements NewsSourceInterface
 {
+    private const PAGE_SIZE = 50;
+
+    private const MAX_PAGES = 20;
+
     /**
      * Create a new class instance.
      */
@@ -22,75 +26,40 @@ class GuardianAdapter implements NewsSourceInterface
     }
 
     /**
-     * Fetch raw articles from The Guardian /search endpoint.
+     * Fetch all articles published today from The Guardian /search endpoint.
+     *
+     * Paginates through all available pages until every article for the day
+     * is collected or the page limit is reached.
      *
      * @return array<int, array<string, mixed>>
      *
-     * @throws RequestException
      * @throws ConnectionException
      * @throws Exception
      */
     public function fetch(): array
     {
-        $baseUrl = $this->config['base_url'];
-        $apiKey = $this->config['api_key'];
-        $timeout = $this->config['timeout'];
-        $endpoint = $this->config['endpoints']['search'];
+        $today = Carbon::today()->toDateString();
+        $allArticles = [];
+        $page = 1;
 
-        // $randSection = Category::query()->select('slug')->inRandomOrder()->value('slug');
+        do {
+            $result = $this->fetchPage($page, $today);
 
-        try {
-            Log::info('The Guardian: Fetching articles', [
-                'endpoint' => $endpoint,
-                'fetched_at' => Carbon::now()->toIso8601String(),
-            ]);
+            if ($result === null) {
+                break;
+            }
 
-            $response = Http::baseUrl($baseUrl)
-                ->withQueryParameters([
-                    'api-key' => $apiKey,
-                    'q' => 'AI',
-                    'lang' => 'en',
-                    'page' => 1,
-                    'page-size' => 10,
-                    'order-by' => 'newest',
-                    'format' => 'json',
-                    'show-fields' => 'all',
-                    // 'section' => $randSection,
-                ])->timeout($timeout)
-                ->retry(3, 100)
-                ->throw()
-                ->get($endpoint);
+            $allArticles = array_merge($allArticles, $result['articles']);
+            $totalPages = $result['pages'];
+            $page++;
+        } while ($page <= $totalPages && $page <= self::MAX_PAGES);
 
-            $data = $response->json();
-            $articles = $data['response']['results'] ?? [];
+        Log::info('Guardian: finished fetching all pages', [
+            'total_fetched' => count($allArticles),
+            'pages_requested' => $page - 1,
+        ]);
 
-            Log::info('The Guardian: fetched articles successfully', [
-                'count' => count($articles),
-                'total_results' => $data['response']['total'] ?? 0,
-            ]);
-
-            return $articles;
-        } catch (RequestException $re) {
-            Log::error('The Guardian HTTP error', [
-                'status' => $re->response->status(),
-                'message' => $re->getMessage(),
-            ]);
-
-            return [];
-        } catch (ConnectionException $ce) {
-            Log::error('The Guardian connection error', [
-                'message' => $ce->getMessage(),
-            ]);
-
-            throw $ce;
-        } catch (Exception $e) {
-            Log::error('The Guardian adapter error', [
-                'message' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-            ]);
-
-            throw $e;
-        }
+        return $allArticles;
     }
 
     /**
@@ -151,5 +120,73 @@ class GuardianAdapter implements NewsSourceInterface
             'published_at' => Carbon::parse($data['webPublicationDate'])->toDateTimeString(),
             'categories' => [$category->slug],
         ];
+    }
+
+    /**
+     * Fetch a single page of results from The Guardian API.
+     *
+     * Returns null on HTTP errors, throws on connection errors.
+     *
+     * @return array{articles: array<int, mixed>, pages: int}|null
+     *
+     * @throws ConnectionException
+     * @throws Exception
+     */
+    private function fetchPage(int $page, string $date): ?array
+    {
+        $baseUrl = $this->config['base_url'];
+        $apiKey = $this->config['api_key'];
+        $timeout = $this->config['timeout'];
+        $endpoint = $this->config['endpoints']['search'];
+
+        try {
+            Log::info('The Guardian: fetching page', [
+                'page' => $page,
+                'date' => $date,
+            ]);
+
+            $response = Http::baseUrl($baseUrl)
+                ->withQueryParameters([
+                    'api-key' => $apiKey,
+                    'from-date' => $date,
+                    'to-date' => $date,
+                    'lang' => 'en',
+                    'page' => $page,
+                    'page-size' => self::PAGE_SIZE,
+                    'order-by' => 'newest',
+                    'format' => 'json',
+                    'show-fields' => 'all',
+                ])->timeout($timeout)
+                ->retry(3, 100)
+                ->throw()
+                ->get($endpoint);
+
+            $data = $response->json();
+            $responseBody = $data['response'] ?? [];
+
+            return [
+                'articles' => $responseBody['results'] ?? [],
+                'pages' => $responseBody['pages'] ?? 1,
+            ];
+        } catch (RequestException $re) {
+            Log::error('The Guardian HTTP error', [
+                'page' => $page,
+                'status' => $re->response->status(),
+                'message' => $re->getMessage(),
+            ]);
+
+            return null;
+        } catch (ConnectionException $ce) {
+            Log::error('The Guardian connection error', ['message' => $ce->getMessage()]);
+
+            throw $ce;
+        } catch (Exception $e) {
+            Log::error('The Guardian adapter error', [
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            throw $e;
+        }
     }
 }

--- a/app/Services/Adapters/NYTimesAdapter.php
+++ b/app/Services/Adapters/NYTimesAdapter.php
@@ -71,7 +71,7 @@ class NYTimesAdapter implements NewsSourceInterface
                 'total_results' => $data['response']['meta']['hits'] ?? 0,
             ]);
 
-            return array_slice($articles, 0, 10);
+            return $articles;
         } catch (RequestException $re) {
             Log::error('NYTimes HTTP error', [
                 'status' => $re->response->status(),

--- a/app/Services/Adapters/NewsApiAdapter.php
+++ b/app/Services/Adapters/NewsApiAdapter.php
@@ -12,77 +12,52 @@ use Illuminate\Support\Facades\Log;
 
 class NewsApiAdapter implements NewsSourceInterface
 {
+    private const PAGE_SIZE = 100;
+
+    private const MAX_PAGES = 10;
+
     public function __construct(private array $config = [])
     {
         $this->config = config('news.sources.newsapi');
     }
 
     /**
-     * Fetch raw articles from the NewsAPI /everything endpoint.
+     * Fetch all articles published today from the NewsAPI /everything endpoint.
+     *
+     * Paginates through all available pages until every article for the day
+     * is collected or the API limit is reached.
      *
      * @return array<int, array<string, mixed>>
      *
-     * @throws RequestException
      * @throws ConnectionException
      * @throws Exception
      */
     public function fetch(): array
     {
-        $baseUrl = $this->config['base_url'];
-        $apiKey = $this->config['api_key'];
-        $timeout = $this->config['timeout'];
-        $endpoint = $this->config['endpoints']['everything'];
+        $today = Carbon::today()->toDateString();
+        $allArticles = [];
+        $page = 1;
 
-        try {
-            Log::info('NewsAPI: Fetching articles', [
-                'endpoint' => $endpoint,
-                'fetched_at' => Carbon::now()->toIso8601String(),
-            ]);
+        do {
+            $result = $this->fetchPage($page, $today);
 
-            $response = Http::baseUrl($baseUrl)
-                ->withQueryParameters([
-                    'apiKey' => $apiKey,
-                    'q' => 'AI',
-                    'language' => 'en',
-                    'sortBy' => 'publishedAt',
-                    'pageSize' => 10,
-                    'page' => 1,
-                ])->timeout($timeout)
-                ->retry(3, 100)
-                ->throw()
-                ->get($endpoint);
+            if ($result === null) {
+                break;
+            }
 
-            $data = $response->json();
-            $articles = $data['articles'] ?? [];
+            $allArticles = array_merge($allArticles, $result['articles']);
+            $totalResults = $result['totalResults'];
+            $page++;
 
-            Log::info('NewsAPI: fetched articles successfully', [
-                'count' => count($articles),
-                'total_results' => $data['totalResults'] ?? 0,
-            ]);
+            $hasMorePages = count($allArticles) < $totalResults && ! empty($result['articles']);
+        } while ($hasMorePages && $page <= self::MAX_PAGES);
 
-            return $articles;
-        } catch (RequestException $re) {
-            Log::error('NewsAPI HTTP error', [
-                'status' => $re->response->status(),
-                'message' => $re->getMessage(),
-            ]);
+        Log::info('NewsAPI: finished fetching all pages', [
+            'total_fetched' => count($allArticles),
+            'pages_requested' => $page - 1,
+        ]);
 
-            return [];
-        } catch (ConnectionException $ce) {
-            Log::error('NewsAPI connection error', [
-                'message' => $ce->getMessage(),
-            ]);
-
-            throw $ce;
-        } catch (Exception $e) {
-            Log::error('NewsAPI adapter error', [
-                'message' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-            ]);
-
-            throw $e;
-        }
-
+        return $allArticles;
     }
 
     /**
@@ -130,5 +105,71 @@ class NewsApiAdapter implements NewsSourceInterface
             'published_at' => $publishedAt->toDateTimeString(),
             'categories' => $categories,
         ];
+    }
+
+    /**
+     * Fetch a single page of results from NewsAPI.
+     *
+     * Returns null on HTTP errors (rate limit, auth), throws on connection errors.
+     *
+     * @return array{articles: array<int, mixed>, totalResults: int}|null
+     *
+     * @throws ConnectionException
+     * @throws Exception
+     */
+    private function fetchPage(int $page, string $date): ?array
+    {
+        $baseUrl = $this->config['base_url'];
+        $apiKey = $this->config['api_key'];
+        $timeout = $this->config['timeout'];
+        $endpoint = $this->config['endpoints']['everything'];
+
+        try {
+            Log::info('NewsAPI: fetching page', [
+                'page' => $page,
+                'date' => $date,
+            ]);
+
+            $response = Http::baseUrl($baseUrl)
+                ->withQueryParameters([
+                    'apiKey' => $apiKey,
+                    'q' => 'AI',
+                    'language' => 'en',
+                    'from' => $date,
+                    'to' => $date,
+                    'sortBy' => 'publishedAt',
+                    'pageSize' => self::PAGE_SIZE,
+                    'page' => $page,
+                ])->timeout($timeout)
+                ->retry(3, 100)
+                ->throw()
+                ->get($endpoint);
+
+            $data = $response->json();
+
+            return [
+                'articles' => $data['articles'] ?? [],
+                'totalResults' => $data['totalResults'] ?? 0,
+            ];
+        } catch (RequestException $re) {
+            Log::error('NewsAPI HTTP error', [
+                'page' => $page,
+                'status' => $re->response->status(),
+                'message' => $re->getMessage(),
+            ]);
+
+            return null;
+        } catch (ConnectionException $ce) {
+            Log::error('NewsAPI connection error', ['message' => $ce->getMessage()]);
+
+            throw $ce;
+        } catch (Exception $e) {
+            Log::error('NewsAPI adapter error', [
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            throw $e;
+        }
     }
 }

--- a/app/Services/NewsAggregationService.php
+++ b/app/Services/NewsAggregationService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Article;
+use App\Models\Category;
+use App\Models\Source;
+use Illuminate\Support\Facades\Log;
+
+class NewsAggregationService
+{
+    /**
+     * Save a normalized article to the database with deduplication.
+     *
+     * Uses updateOrCreate keyed on (source_id, external_id) to prevent
+     * duplicate articles across scheduler reruns and overlapping fetches.
+     *
+     * @param  array{
+     *     external_id: string,
+     *     title: string,
+     *     description: string|null,
+     *     content: string|null,
+     *     author: string|null,
+     *     url: string,
+     *     image_url: string|null,
+     *     published_at: string,
+     *     categories: array<string>,
+     * }  $data
+     */
+    public function saveArticle(Source $source, array $data): void
+    {
+        if (empty($data) || empty($data['external_id']) || empty($data['url'])) {
+            return;
+        }
+
+        $article = Article::updateOrCreate(
+            [
+                'source_id' => $source->id,
+                'external_id' => $data['external_id'],
+            ],
+            [
+                'title' => $data['title'],
+                'description' => $data['description'] ?? null,
+                'content' => $data['content'] ?? null,
+                'author' => $data['author'] ?? null,
+                'url' => $data['url'],
+                'image_url' => $data['image_url'] ?? null,
+                'published_at' => $data['published_at'],
+                'fetched_at' => now(),
+            ]
+        );
+
+        if (! empty($data['categories'])) {
+            $categoryIds = Category::query()
+                ->whereIn('slug', $data['categories'])
+                ->pluck('id');
+
+            $article->categories()->sync($categoryIds);
+        }
+
+        Log::debug('Article saved', [
+            'source' => $source->slug,
+            'external_id' => $data['external_id'],
+            'url' => $data['url'],
+        ]);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       DB_HOST: mariadb
       REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ""
     networks:
       - news_aggregator_network
     depends_on:
@@ -85,6 +87,8 @@ services:
     environment:
       DB_HOST: mariadb
       REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ""
     networks:
       - news_aggregator_network
     depends_on:

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('news:aggregate')->dailyAt('00:00');

--- a/tests/Feature/Api/V1/ArticleTest.php
+++ b/tests/Feature/Api/V1/ArticleTest.php
@@ -97,3 +97,44 @@ test('returns correct category fields with an article', function () {
     expect($response->json('data.categories.0'))
         ->toMatchArray(['id' => $category->id, 'name' => $category->name, 'slug' => $category->slug]);
 });
+
+// --- Full-Text Search (#20) ---
+
+test('accepts a search query and returns a successful response', function () {
+    Article::factory()->count(3)->create();
+
+    $this->getJson('/api/v1/articles?q=technology')
+        ->assertSuccessful()
+        ->assertJsonStructure(['data', 'meta']);
+})->skip(
+    fn () => config('database.default') === 'sqlite',
+    'whereFullText is not supported in SQLite; runs on MariaDB in production.'
+);
+
+test('returns all articles when q param is empty', function () {
+    Article::factory()->count(5)->create();
+
+    $withoutQ = $this->getJson('/api/v1/articles')->assertSuccessful();
+    $withEmptyQ = $this->getJson('/api/v1/articles?q=')->assertSuccessful();
+
+    expect($withoutQ->json('meta.total'))->toBe($withEmptyQ->json('meta.total'));
+});
+
+test('returns all articles when q is only whitespace', function () {
+    Article::factory()->count(3)->create();
+
+    $withoutQ = $this->getJson('/api/v1/articles')->assertSuccessful();
+    // URL-encode spaces (%20) to form a valid URI
+    $withWhitespace = $this->getJson('/api/v1/articles?q=%20%20%20')->assertSuccessful();
+
+    expect($withoutQ->json('meta.total'))->toBe($withWhitespace->json('meta.total'));
+})->skip(
+    fn () => config('database.default') === 'sqlite',
+    'whereFullText is not supported in SQLite; runs on MariaDB in production.'
+);
+
+test('returns 422 when q exceeds maximum length', function () {
+    $this->getJson('/api/v1/articles?q=' . str_repeat('a', 256))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['q']);
+});

--- a/tests/Feature/Console/AggregateNewsCommandTest.php
+++ b/tests/Feature/Console/AggregateNewsCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Jobs\FetchArticlesJob;
+use App\Models\Source;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+test('command dispatches a job for each active source', function () {
+    Queue::fake();
+
+    $sources = Source::factory()->count(3)->create();
+
+    $this->artisan('news:aggregate')->assertSuccessful();
+
+    Queue::assertPushed(FetchArticlesJob::class, 3);
+
+    $sources->each(function ($source) {
+        Queue::assertPushed(FetchArticlesJob::class, fn ($job) => $job->sourceSlug === $source->slug);
+    });
+});
+
+test('command does not dispatch jobs for inactive sources', function () {
+    Queue::fake();
+
+    Source::factory()->create(['slug' => 'active-source']);
+    Source::factory()->inactive()->create(['slug' => 'inactive-source']);
+
+    $this->artisan('news:aggregate')->assertSuccessful();
+
+    Queue::assertPushed(FetchArticlesJob::class, 1);
+    Queue::assertPushed(FetchArticlesJob::class, fn ($job) => $job->sourceSlug === 'active-source');
+    Queue::assertNotPushed(FetchArticlesJob::class, fn ($job) => $job->sourceSlug === 'inactive-source');
+});
+
+test('command outputs warning and exits successfully when no active sources exist', function () {
+    Queue::fake();
+
+    $this->artisan('news:aggregate')
+        ->assertSuccessful()
+        ->expectsOutput('No active sources found.');
+
+    Queue::assertNothingPushed();
+});
+
+test('command outputs the dispatched source names', function () {
+    Queue::fake();
+
+    $source = Source::factory()->create(['name' => 'The Guardian', 'slug' => 'guardian']);
+
+    $this->artisan('news:aggregate')
+        ->assertSuccessful()
+        ->expectsOutput("Dispatched job for: {$source->name}");
+});

--- a/tests/Feature/Jobs/FetchArticlesJobTest.php
+++ b/tests/Feature/Jobs/FetchArticlesJobTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Jobs\FetchArticlesJob;
+use App\Models\Article;
+use App\Models\Source;
+use App\Services\Adapters\GuardianAdapter;
+use App\Services\Adapters\NewsApiAdapter;
+use App\Services\Adapters\NYTimesAdapter;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+function rawArticle(array $overrides = []): array
+{
+    return array_merge([
+        'external_id' => 'ext-job-001',
+        'title' => 'Job Test Article',
+        'description' => 'Description',
+        'content' => 'Content',
+        'author' => 'Author',
+        'url' => 'https://example.com/job-article',
+        'image_url' => null,
+        'published_at' => '2026-01-01 00:00:00',
+        'categories' => [],
+    ], $overrides);
+}
+
+test('job has correct retry configuration', function () {
+    $job = new FetchArticlesJob('newsapi');
+
+    expect($job->tries)->toBe(3)
+        ->and($job->backoff)->toBe([30, 120, 600])
+        ->and($job->timeout)->toBe(120);
+});
+
+test('job saves articles from the adapter to the database', function () {
+    $source = Source::factory()->create(['slug' => 'newsapi']);
+
+    $this->mock(NewsApiAdapter::class, function ($mock) {
+        $mock->shouldReceive('fetch')->once()->andReturn([['raw' => 'data']]);
+        $mock->shouldReceive('normalize')->once()->andReturn(rawArticle());
+    });
+
+    (new FetchArticlesJob('newsapi'))->handle(app(\App\Services\NewsAggregationService::class));
+
+    expect(Article::count())->toBe(1);
+});
+
+test('job updates last_fetched_at on the source after processing', function () {
+    $source = Source::factory()->create(['slug' => 'guardian', 'last_fetched_at' => null]);
+
+    $this->mock(GuardianAdapter::class, function ($mock) {
+        $mock->shouldReceive('fetch')->once()->andReturn([]);
+    });
+
+    (new FetchArticlesJob('guardian'))->handle(app(\App\Services\NewsAggregationService::class));
+
+    expect($source->fresh()->last_fetched_at)->not->toBeNull();
+});
+
+test('job continues processing remaining articles when one fails to save', function () {
+    $source = Source::factory()->create(['slug' => 'nytimes']);
+
+    $this->mock(NYTimesAdapter::class, function ($mock) {
+        $mock->shouldReceive('fetch')->once()->andReturn([['raw' => 'bad'], ['raw' => 'good']]);
+        $mock->shouldReceive('normalize')
+            ->twice()
+            ->andReturn([], rawArticle());
+    });
+
+    (new FetchArticlesJob('nytimes'))->handle(app(\App\Services\NewsAggregationService::class));
+
+    expect(Article::count())->toBe(1);
+});
+
+test('job throws when source slug does not exist in the database', function () {
+    expect(fn () => (new FetchArticlesJob('unknown-source'))
+        ->handle(app(\App\Services\NewsAggregationService::class))
+    )->toThrow(ModelNotFoundException::class);
+});
+
+test('job throws when source is inactive', function () {
+    Source::factory()->inactive()->create(['slug' => 'newsapi']);
+
+    expect(fn () => (new FetchArticlesJob('newsapi'))
+        ->handle(app(\App\Services\NewsAggregationService::class))
+    )->toThrow(ModelNotFoundException::class);
+});
+
+test('failed method logs a critical message', function () {
+    Log::shouldReceive('critical')->once()->with(
+        'FetchArticlesJob exhausted all retries',
+        Mockery::subset(['source' => 'guardian'])
+    );
+
+    $job = new FetchArticlesJob('guardian');
+    $job->failed(new RuntimeException('Connection refused'));
+});
+
+test('job can be dispatched to the queue', function () {
+    Queue::fake();
+
+    FetchArticlesJob::dispatch('newsapi');
+
+    Queue::assertPushed(FetchArticlesJob::class, function ($job) {
+        return $job->sourceSlug === 'newsapi';
+    });
+});

--- a/tests/Feature/Services/GuardianAdapterTest.php
+++ b/tests/Feature/Services/GuardianAdapterTest.php
@@ -176,7 +176,7 @@ test('fetch returns empty array when results key is absent', function () {
 test('fetch returns empty array and logs error on http error', function () {
     Http::fake(['*' => Http::response(['message' => 'Too Many Requests'], 429)]);
 
-    Log::shouldReceive('info')->once();
+    Log::shouldReceive('info')->times(2);
     Log::shouldReceive('error')->once()->with('The Guardian HTTP error', Mockery::type('array'));
 
     $adapter = new GuardianAdapter;

--- a/tests/Feature/Services/NYTimesAdapterTest.php
+++ b/tests/Feature/Services/NYTimesAdapterTest.php
@@ -178,7 +178,7 @@ test('normalize reuses existing category without creating duplicate', function (
 // fetch()
 // ---------------------------------------------------------------------------
 
-test('fetch returns sliced articles on successful response', function () {
+test('fetch returns all articles on successful response', function () {
     $docs = array_map(fn ($i) => [
         '_id' => "nyt://article/id-{$i}",
         'headline' => ['main' => "Article {$i}"],
@@ -196,7 +196,7 @@ test('fetch returns sliced articles on successful response', function () {
     $adapter = new NYTimesAdapter;
     $articles = $adapter->fetch();
 
-    expect($articles)->toHaveCount(10)
+    expect($articles)->toHaveCount(20)
         ->and($articles[0]['headline']['main'])->toBe('Article 1');
 });
 

--- a/tests/Feature/Services/NewsAggregationServiceTest.php
+++ b/tests/Feature/Services/NewsAggregationServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Models\Article;
+use App\Models\Category;
+use App\Models\Source;
+use App\Services\NewsAggregationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function articleData(array $overrides = []): array
+{
+    return array_merge([
+        'external_id' => 'ext-001',
+        'title' => 'Test Article Title',
+        'description' => 'A description',
+        'content' => 'Full content here',
+        'author' => 'John Doe',
+        'url' => 'https://example.com/article-001',
+        'image_url' => 'https://example.com/image.jpg',
+        'published_at' => '2026-01-01 00:00:00',
+        'categories' => [],
+    ], $overrides);
+}
+
+test('saveArticle creates a new article', function () {
+    $source = Source::factory()->create();
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, articleData());
+
+    expect(Article::count())->toBe(1)
+        ->and(Article::first()->title)->toBe('Test Article Title')
+        ->and(Article::first()->source_id)->toBe($source->id);
+});
+
+test('saveArticle updates an existing article instead of creating a duplicate', function () {
+    $source = Source::factory()->create();
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, articleData(['title' => 'Original Title']));
+    $service->saveArticle($source, articleData(['title' => 'Updated Title']));
+
+    expect(Article::count())->toBe(1)
+        ->and(Article::first()->title)->toBe('Updated Title');
+});
+
+test('saveArticle allows the same external_id for different sources', function () {
+    [$sourceA, $sourceB] = Source::factory()->count(2)->create();
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($sourceA, articleData(['url' => 'https://example.com/a']));
+    $service->saveArticle($sourceB, articleData(['url' => 'https://example.com/b']));
+
+    expect(Article::count())->toBe(2);
+});
+
+test('saveArticle syncs categories to the article', function () {
+    $source = Source::factory()->create();
+    Category::factory()->create(['slug' => 'technology']);
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, articleData(['categories' => ['technology']]));
+
+    $article = Article::first();
+    expect($article->categories)->toHaveCount(1)
+        ->and($article->categories->first()->slug)->toBe('technology');
+});
+
+test('saveArticle replaces categories on update', function () {
+    $source = Source::factory()->create();
+    Category::factory()->create(['slug' => 'technology']);
+    Category::factory()->create(['slug' => 'science']);
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, articleData(['categories' => ['technology']]));
+    $service->saveArticle($source, articleData(['categories' => ['science']]));
+
+    $article = Article::first();
+    expect($article->categories)->toHaveCount(1)
+        ->and($article->categories->first()->slug)->toBe('science');
+});
+
+test('saveArticle ignores unknown category slugs', function () {
+    $source = Source::factory()->create();
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, articleData(['categories' => ['nonexistent-category']]));
+
+    expect(Article::count())->toBe(1)
+        ->and(Article::first()->categories)->toBeEmpty();
+});
+
+test('saveArticle skips when data is empty', function () {
+    $source = Source::factory()->create();
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, []);
+
+    expect(Article::count())->toBe(0);
+});
+
+test('saveArticle skips when external_id is missing', function () {
+    $source = Source::factory()->create();
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, articleData(['external_id' => '']));
+
+    expect(Article::count())->toBe(0);
+});
+
+test('saveArticle skips when url is missing', function () {
+    $source = Source::factory()->create();
+    $service = app(NewsAggregationService::class);
+
+    $service->saveArticle($source, articleData(['url' => '']));
+
+    expect(Article::count())->toBe(0);
+});

--- a/tests/Feature/Services/NewsApiAdapterTest.php
+++ b/tests/Feature/Services/NewsApiAdapterTest.php
@@ -106,7 +106,7 @@ test('fetch returns empty array when articles key is absent', function () {
 test('fetch returns empty array and logs error on http error', function () {
     Http::fake(['*' => Http::response(['message' => 'Too Many Requests'], 429)]);
 
-    Log::shouldReceive('info')->once();
+    Log::shouldReceive('info')->times(2);
     Log::shouldReceive('error')->once()->with('NewsAPI HTTP error', \Mockery::type('array'));
 
     $adapter = new NewsApiAdapter;


### PR DESCRIPTION
  Description:
  Closes #19

  ## Summary

  - Add `NewsAggregationService` — persists normalized articles via `updateOrCreate` on `(source_id, external_id)` and syncs categories through the pivot table
  - Add `FetchArticlesJob` — queued job per source with 3 retries and exponential backoff (30s → 2min → 10min), isolated so a failing source does not block others
  - Add `AggregateNewsCommand` — dispatches one `FetchArticlesJob` per active source; scheduled daily at midnight via `routes/console.php`
  - Extend `ArticleController@index` with keyword, source, category, author, and date range filters backed by `ListArticlesRequest` form request validation
  - Update README to reflect the full aggregation workflow

  ## Changes

  | File | What |
  |------|------|
  | `app/Services/NewsAggregationService.php` | New — deduplication and persistence logic |
  | `app/Jobs/FetchArticlesJob.php` | New — queued job with retry/backoff config |
  | `app/Console/Commands/AggregateNewsCommand.php` | New — Artisan command dispatching jobs per source |
  | `app/Http/Requests/ListArticlesRequest.php` | New — validation for article filter query params |
  | `app/Http/Controllers/API/V1/ArticleController.php` | Updated — keyword/source/category/author/date filters |
  | `routes/console.php` | Updated — schedule `AggregateNewsCommand` daily at midnight |
  | `docker-compose.yml` | Updated — queue worker configuration |
  | `README.md` | Updated — aggregation workflow and manual trigger docs |

  ## Test plan

  **NewsAggregationService**
  - [x] Saves new article to database
  - [x] Updates existing article on duplicate `(source_id, external_id)`
  - [x] Syncs categories via pivot table

  **FetchArticlesJob**
  - [x] Fetches, normalizes, and saves articles for a source
  - [x] Skips articles where `normalize()` returns `[]`
  - [x] Retries on failure with correct backoff config

  **AggregateNewsCommand**
  - [x] Dispatches one job per active source
  - [x] Skips inactive sources

  **Article filtering**
  - [x] Filters by keyword (title/description/content)
  - [x] Filters by source slug
  - [x] Filters by category slug
  - [x] Filters by author
  - [x] Filters by date range (`from` / `to`)